### PR TITLE
[feature] add cohere client

### DIFF
--- a/manifest/caches/cache.py
+++ b/manifest/caches/cache.py
@@ -3,7 +3,17 @@ import json
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, Union
 
-from manifest.response import Response
+from manifest.response import CohereResponse, Response
+
+RESPONSE_CONSTRUCTORS = {
+    "openai": Response,
+    "cohere": CohereResponse,
+    "ai21": Response,
+    "huggingface": Response,
+    "opt": Response,
+    "dummy": Response,
+    "zoo": Response,
+}
 
 
 def request_to_key(request: Dict) -> str:
@@ -137,4 +147,8 @@ class Cache(ABC):
             response = compute()
             self.set_key(key, response_to_key(response))
             cached = False
-        return Response(response, cached, request)
+        client_name = compute.__module__.split(".")[-1]
+        if client_name in RESPONSE_CONSTRUCTORS:
+            return RESPONSE_CONSTRUCTORS[client_name](response, cached, request)
+        else:
+            return Response(response, cached, request)

--- a/manifest/clients/cohere.py
+++ b/manifest/clients/cohere.py
@@ -1,0 +1,135 @@
+"""Cohere client."""
+
+import json
+import logging
+import os
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import cohere
+
+from manifest.clients.client import Client
+
+logging.getLogger("cohere").setLevel(logging.WARNING)
+logger = logging.getLogger(__name__)
+
+COHERE_MODELS = {"small", "medium", "large", "xlarge"}
+
+# Params are defined in https://docs.cohere.ai/generate-reference
+COHERE_PARAMS = {
+    "model": ("model", "xlarge"),
+    "max_tokens": ("max_tokens", 20),
+    "temperature": ("temperature", 0.75),
+    "num_generations": ("num_generations", 1),
+    "k": ("k", 0),
+    "p": ("p", 0.75),
+    "frequency_penalty": ("frequency_penalty", 0.0),
+    "presence_penalty": ("presence_penalty", 0.0),
+    "stop_sequences": ("stop_sequences", []),
+    "return_likelihoods": ("return_likelihoods", ""),
+    "logit_bias": ("logit_bias", {}),
+}
+
+
+class CohereClient(Client):
+    """Cohere client."""
+
+    def connect(
+        self,
+        connection_str: Optional[str] = None,
+        client_args: Dict[str, Any] = {},
+    ) -> None:
+        """
+        Connect to the Cohere server.
+
+        connection_str is passed as default COHERE_API_KEY if variable not set.
+
+        Args:
+            connection_str: connection string.
+            client_args: client arguments.
+        """
+        api_key = os.environ.get("COHERE_API_KEY", connection_str)
+        if api_key is None:
+            raise ValueError(
+                "Cohere API key not set. Set COHERE_API_KEY environment "
+                "variable or pass through `connection_str`."
+            )
+        self.co = cohere.Client(api_key)
+        for key in COHERE_PARAMS:
+            setattr(self, key, client_args.pop(key, COHERE_PARAMS[key][1]))
+        if getattr(self, "model") not in COHERE_MODELS:
+            raise ValueError(
+                f"Invalid model {getattr(self, 'model')}. Must be {COHERE_MODELS}."
+            )
+
+    def close(self) -> None:
+        """Close the client."""
+
+    def get_model_params(self) -> Dict:
+        """
+        Get model params.
+
+        By getting model params from the server, we can add to request
+        and make sure cache keys are unique to model.
+
+        Returns:
+            model params.
+        """
+        return {"model_name": "model", "model": getattr(self, "model")}
+
+    def get_model_inputs(self) -> List:
+        """
+        Get allowable model inputs.
+
+        Returns:
+            model inputs.
+        """
+        return list(COHERE_PARAMS.keys())
+
+    def get_request(
+        self, query: str, request_args: Dict[str, Any] = {}
+    ) -> Tuple[Callable[[], Dict], Dict]:
+        """
+        Get request string function.
+
+        Args:
+            query: query string.
+
+        Returns:
+            request function that takes no input.
+            request parameters as dict.
+        """
+        request_params = {"prompt": query}
+        for key in COHERE_PARAMS:
+            request_params[COHERE_PARAMS[key][0]] = request_args.pop(
+                key, getattr(self, key)
+            )
+
+        def _run_generation() -> Dict:
+            try:
+                response = self.co.generate(**request_params)
+                return json.loads(
+                    json.dumps(
+                        response, default=lambda o: getattr(o, "__dict__", str(o))
+                    )
+                )
+            except cohere.CohereError as e:
+                logger.error(e)
+                raise e
+
+        return _run_generation, request_params
+
+    def get_choice_logit_request(
+        self, query: str, gold_choices: List[str], request_args: Dict[str, Any] = {}
+    ) -> Tuple[Callable[[], Dict], Dict]:
+        """
+        Get request string function for choosing max choices.
+
+        Args:
+            query: query string.
+            gold_choices: choices for model to choose from via max logits.
+
+        Returns:
+            request function that takes no input.
+            request parameters as dict.
+        """
+        raise NotImplementedError("Cohere does not support choice logit request.")

--- a/manifest/manifest.py
+++ b/manifest/manifest.py
@@ -8,6 +8,7 @@ from manifest.caches.noop import NoopCache
 from manifest.caches.redis import RedisCache
 from manifest.caches.sqlite import SQLiteCache
 from manifest.clients.ai21 import AI21Client
+from manifest.clients.cohere import CohereClient
 from manifest.clients.dummy import DummyClient
 from manifest.clients.huggingface import HuggingFaceClient
 from manifest.clients.openai import OpenAIClient
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 CLIENT_CONSTRUCTORS = {
     "openai": OpenAIClient,
+    "cohere": CohereClient,
     "ai21": AI21Client,
     "huggingface": HuggingFaceClient,
     "opt": OPTClient,

--- a/manifest/response.py
+++ b/manifest/response.py
@@ -139,3 +139,59 @@ class Response:
             string representation of response.
         """
         return str(self)
+
+
+class CohereResponse(Response):
+    """Response class for Cohere client."""
+
+    def __init__(self, response: Dict, cached: bool, request_params: Dict):
+        """Initialize response."""
+        if isinstance(response, dict):
+            self._response = response
+        else:
+            raise ValueError(f"Response must be str or dict. Response is\n{response}.")
+        if ("generations" not in self._response) or (
+            not isinstance(self._response["generations"], list)
+        ):
+            raise ValueError(
+                "Response must be serialized to a dict with a list of generations. "
+                f"Response is\n{self._response}."
+            )
+        if len(self._response["generations"]) > 0:
+            if "text" not in self._response["generations"][0]:
+                raise ValueError(
+                    "Response must be serialized to a dict with a "
+                    "list of generations with text field"
+                )
+            if (
+                "token_likelihoods" in self._response["generations"][0]
+                and self._response["generations"][0]["token_likelihoods"]
+            ):
+                if not isinstance(
+                    self._response["generations"][0]["token_likelihoods"], list
+                ):
+                    raise ValueError(
+                        "Response must be serialized to a dict with a "
+                        "list of generations with token_likelihoods field"
+                    )
+        self._cached = cached
+        self._request_params = request_params
+
+    def get_response(self, stop_token: str = "") -> Union[str, List[str]]:
+        """
+        Get all text results from response.
+
+        Args:
+            stop_token: stop token for string generation
+        """
+        process_result = (
+            lambda x: x.strip().split(stop_token)[0] if stop_token else x.strip()
+        )
+        if len(self._response["generations"]) == 0:
+            return None
+        if len(self._response["generations"]) == 1:
+            return process_result(self._response["generations"][0]["text"])
+        return [
+            process_result(generation["text"])
+            for generation in self._response["generations"]
+        ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ module = [
   "accelerate",
   "accelerate.utils.modeling",
   "transformers",
+  "cohere",
 ]
 
 [tool.isort]

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ VERSION = main_ns["__version__"]
 REQUIRED = [
     "Flask>=2.1.2",
     "accelerate>=0.10.0",
+    "cohere>=2.5.0",
     "dill>=0.3.5",
     "openai>=0.18.1",
     "redis>=4.3.1",


### PR DESCRIPTION
This PR adds [Cohere](https://cohere.ai/) as a client to Manifest. 

Specifically, the `co.generate` endpoint is used. API documentation can be found [here](https://docs.cohere.ai/generate-reference).

All tests pass using
```
export REDIS_PORT="6380"  # or whatever PORT local redis is running for those tests
cd <REDIS_PATH>
docker run -d -p 127.0.0.1:${REDIS_PORT}:6379 -v `pwd`:`pwd` -w `pwd` --name manifest_redis_test redis
make test
```